### PR TITLE
Fix Android release build

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,25 +1,33 @@
-buildscript {
-    repositories {
-        jcenter()
-    }
+def DEFAULT_COMPILE_SDK_VERSION = 28
+def DEFAULT_BUILD_TOOLS_VERSION = '28.0.3'
+def DEFAULT_MIN_SDK_VERSION = 16
+def DEFAULT_TARGET_SDK_VERSION = 28
 
-    dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
-    }
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
 
-allprojects {
-    repositories {
-        mavenLocal()
-        jcenter()
-        maven {
-            // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-            url "$rootDir/../node_modules/react-native/android"
+apply plugin: 'com.android.library'
+apply plugin: 'maven'
+
+buildscript {
+    // The Android Gradle plugin is only required when opening the android folder stand-alone.
+    // This avoids unnecessary downloads and potential conflicts when the library is included as a
+    // module dependency in an application project.
+    // ref: https://docs.gradle.org/current/userguide/tutorial_using_tasks.html#sec:build_script_external_dependencies
+    if (project == rootProject) {
+        repositories {
+            google()
+            jcenter()
+        }
+        dependencies {
+            classpath 'com.android.tools.build:gradle:3.4.1'
         }
     }
 }
 
 apply plugin: 'com.android.library'
+apply plugin: 'maven'
 
 /**
  * Run Proguard to shrink the Java bytecode in release builds.
@@ -27,22 +35,38 @@ apply plugin: 'com.android.library'
 def enableProguardInReleaseBuilds = false
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.0"
-
+    compileSdkVersion safeExtGet('compileSdkVersion', DEFAULT_COMPILE_SDK_VERSION)
+    buildToolsVersion safeExtGet('buildToolsVersion', DEFAULT_BUILD_TOOLS_VERSION)
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 22
+        minSdkVersion safeExtGet('minSdkVersion', DEFAULT_MIN_SDK_VERSION)
+        targetSdkVersion safeExtGet('targetSdkVersion', DEFAULT_TARGET_SDK_VERSION)
         versionCode 1
         versionName "1.0"
     }
-
     buildTypes {
         release {
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }
     }
+    lintOptions {
+        abortOnError false
+    }
+}
+
+repositories {
+    // ref: https://www.baeldung.com/maven-local-repository
+    mavenLocal()
+    maven {
+        // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
+        url "$rootDir/../node_modules/react-native/android"
+    }
+    maven {
+        // Android JSC is installed from npm
+        url "$rootDir/../node_modules/jsc-android/dist"
+    }
+    google()
+    jcenter()
 }
 
 dependencies {


### PR DESCRIPTION
I had a problem to build an Android app with this package with 'release' flag.
Error:
````

* What went wrong:
Execution failed for task ':react-native-get-location:verifyReleaseResources'.
> 1 exception was raised by workers:
  com.android.builder.internal.aapt.v2.Aapt2Exception: Android resource linking failed
 .../node_modules/react-native-get-location/android/build/intermediates/res/merged/release/values-v26/values-v26.xml:7: error: resource android:attr/colorError not found.
.../node_modules/react-native-get-location/android/build/intermediates/res/merged/release/values-v26/values-v26.xml:11: error: resource android:attr/colorError not found.
.../node_modules/react-native-get-location/android/build/intermediates/res/merged/release/values-v26/values-v26.xml:15: error: style attribute 'android:attr/keyboardNavigationCluster' not found.
.../node_modules/react-native-get-location/android/build/intermediates/res/merged/release/values-v28/values-v28.xml:7: error: resource android:attr/dialogCornerRadius not found.
.../node_modules/react-native-get-location/android/build/intermediates/res/merged/release/values-v28/values-v28.xml:11: error: resource android:attr/dialogCornerRadius not found.
.../node_modules/react-native-get-location/android/build/intermediates/res/merged/release/values/values.xml:2740: error: resource android:attr/fontStyle not found.
 .../node_modules/react-native-get-location/android/build/intermediates/res/merged/release/values/values.xml:2741: error: resource android:attr/font not found.
 .../node_modules/react-native-get-location/android/build/intermediates/res/merged/release/values/values.xml:2742: error: resource android:attr/fontWeight not found.
 .../node_modules/react-native-get-location/android/build/intermediates/res/merged/release/values/values.xml:2743: error: resource android:attr/fontVariationSettings not found.
 .../node_modules/react-native-get-location/android/build/intermediates/res/merged/release/values/values.xml:2744: error: resource android:attr/ttcIndex not found.
  error: failed linking references.
````

So I updated `build.gradle` file according to react-native native module development guidelines and upgraded compile SDK version to 28.