### PR TITLE
Fix a duplicated type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -27,10 +27,6 @@ export class LocationError extends Error {
   code: LocationErrorCode;
 }
 
-export class LocationError extends Error {
-  code: LocationErrorCode;
-}
-
 export default class GetLocation {
   static getCurrentPosition(options: GetCurrentPositionOptions): Promise<Location>;
 }


### PR DESCRIPTION
When `skipLibChecks` is set to `false` in a project's `tsconfig.json` (which is not advisable, but is the default), type-checking this library currently produces this error:

```
node_modules/react-native-get-location/index.d.ts:26:14 - error TS2300: Duplicate identifier 'LocationError'.

26 export class LocationError extends Error {
                ~~~~~~~~~~~~~

node_modules/react-native-get-location/index.d.ts:30:14 - error TS2300: Duplicate identifier 'LocationError'.

30 export class LocationError extends Error {
                ~~~~~~~~~~~~~
```

It should be fixed by removing this duplicate identifier, which appears to have been added accidentally here: https://github.com/douglasjunior/react-native-get-location/pull/16