### PR TITLE
Fix getCurrentPosition error 'undefined rationale'

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ export default {
         rationale: undefined,
     }) {
         if (OS === 'android') {
-            await requestAndroidPermission(options.enableHighAccuracy, rationale);
+            await requestAndroidPermission(options.enableHighAccuracy, options.rationale);
         }
         try {
             const location = await ReactNativeGetLocation.getCurrentPosition(options);


### PR DESCRIPTION
This a fix for the error I encountered on version 3.0.0 on Android. Calling **getCurrentPosition** on Android even with a Rationale object passed will return an error `undefined Property 'rationale' doesn't exist`. I found out that the function was using the default value **undefined** instead of using the passed value **options.rationale**. 

<img width="385" alt="Screenshot 2023-03-06 at 10 13 42 AM" src="https://user-images.githubusercontent.com/25720149/223006434-119fd70b-2b24-4aaf-9818-51093b9c6937.png">