### PR TITLE
fix(location): update ios location implementation to handle thread issues

### DIFF
--- a/ios/ReactNativeGetLocationLibrary/LocationModuleImpl.m
+++ b/ios/ReactNativeGetLocationLibrary/LocationModuleImpl.m
@@ -23,13 +23,13 @@
 #import "LocationModuleImpl.h"
 #import <React/RCTLog.h>
 
-@implementation LocationModuleImpl
-
-NSTimer* mTimer;
-CLLocationManager* mLocationManager;
-RCTPromiseResolveBlock mResolve;
-RCTPromiseRejectBlock mReject;
-double mTimeout;
+@implementation LocationModuleImpl {
+    NSTimer* mTimer;
+    CLLocationManager* mLocationManager;
+    RCTPromiseResolveBlock mResolve;
+    RCTPromiseRejectBlock mReject;
+    double mTimeout;
+}
 
 - (instancetype)init {
     self = [super init];
@@ -44,20 +44,20 @@ double mTimeout;
     dispatch_async(dispatch_get_main_queue(), ^{
         @try {
             [self cancelPreviousRequest];
-                       
+
             bool enableHighAccuracy = [RCTConvert BOOL:options[@"enableHighAccuracy"]];
             double timeout = [RCTConvert double:options[@"timeout"]];
-            
+
             CLLocationManager *locationManager = [[CLLocationManager alloc] init];
             locationManager.delegate = self;
             locationManager.distanceFilter = kCLDistanceFilterNone;
             locationManager.desiredAccuracy = enableHighAccuracy ? kCLLocationAccuracyBest : kCLLocationAccuracyNearestTenMeters;
-            
-            mResolve = resolve;
-            mReject = reject;
-            mLocationManager = locationManager;
-            mTimeout = timeout;
-            
+
+            self->mResolve = resolve;
+            self->mReject = reject;
+            self->mLocationManager = locationManager;
+            self->mTimeout = timeout;
+
             [self startUpdatingLocation];
         }
         @catch (NSException *exception) {
@@ -67,7 +67,7 @@ double mTimeout;
             [info setValue:exception.callStackReturnAddresses forKey:@"ExceptionCallStackReturnAddresses"];
             [info setValue:exception.callStackSymbols forKey:@"ExceptionCallStackSymbols"];
             [info setValue:exception.userInfo forKey:@"ExceptionUserInfo"];
-            
+
             NSError *error = [[NSError alloc] initWithDomain:@"Location service is disabled or unavailable" code:1 userInfo:info];
             reject(@"UNAVAILABLE", @"Location service is disabled or unavailable", error);
         }
@@ -77,7 +77,7 @@ double mTimeout;
 - (void) locationManager:(CLLocationManager *)manager didUpdateLocations:(NSArray<CLLocation *> *)locations {
     if (locations.count > 0 && mResolve != nil) {
         CLLocation* location = locations[0];
-        
+
         NSDictionary* locationResult = @{
             @"latitude": @(location.coordinate.latitude),
             @"longitude": @(location.coordinate.longitude),
@@ -88,7 +88,7 @@ double mTimeout;
             @"verticalAccuracy": @(location.verticalAccuracy),
             @"course": @(location.course),
         };
-        
+
         mResolve(locationResult);
     }
     [self clearReferences];
@@ -109,10 +109,17 @@ double mTimeout;
 }
 
 - (void) clearReferences {
+    if (![NSThread isMainThread]) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self clearReferences];
+        });
+        return;
+    }
     if (mTimer != nil) {
         [mTimer invalidate];
     }
     if (mLocationManager != nil) {
+        mLocationManager.delegate = nil;
         [mLocationManager stopUpdatingLocation];
     }
     mResolve = nil;
@@ -123,7 +130,7 @@ double mTimeout;
 }
 
 - (void) cancelPreviousRequest {
-    if (mLocationManager != nil) {
+    if (mLocationManager != nil && mReject != nil) {
         mReject(@"CANCELLED", @"Location cancelled by user or by another request", nil);
     }
     [self clearReferences];
@@ -135,10 +142,10 @@ double mTimeout;
         [mLocationManager requestWhenInUseAuthorization];
         return;
     }
-    
+
     NSLog(@"[locationManager startUpdatingLocation]");
     [mLocationManager startUpdatingLocation];
-    
+
     if (mTimeout > 0) {
         NSTimeInterval timeoutInterval = mTimeout / 1000.0;
         mTimer = [NSTimer scheduledTimerWithTimeInterval:timeoutInterval
@@ -150,39 +157,53 @@ double mTimeout;
 }
 
 - (void)locationManagerDidChangeAuthorization:(CLLocationManager *)manager {
+    CLAuthorizationStatus status = [manager authorizationStatus];
+
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        if (![CLLocationManager locationServicesEnabled]) {
-            mReject(@"UNAVAILABLE", @"Location service is disabled or unavailable", nil);
-            [self clearReferences];
-            return;
-        }
-        
-        switch ([manager authorizationStatus]) {
-            case kCLAuthorizationStatusAuthorizedAlways:
-            case kCLAuthorizationStatusAuthorizedWhenInUse: {
-                [self startUpdatingLocation];
-                break;
-            }
-            case kCLAuthorizationStatusNotDetermined: {
-                // user has not authorized ou denied yet
-                break;
-            }
-            case kCLAuthorizationStatusDenied:
-            case kCLAuthorizationStatusRestricted:
-            default: {
-                if (mReject != nil) {
-                    mReject(@"UNAUTHORIZED", @"Location permission denied by the user", nil);
-                }
-                [self clearReferences];
-                break;
-            }
-        }
+        BOOL servicesEnabled = [CLLocationManager locationServicesEnabled];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self handleAuthorizationStatus:status servicesEnabled:servicesEnabled];
+        });
     });
 }
 
+- (void) handleAuthorizationStatus:(CLAuthorizationStatus)status servicesEnabled:(BOOL)servicesEnabled {
+    if (!servicesEnabled) {
+        if (mReject != nil) {
+            mReject(@"UNAVAILABLE", @"Location service is disabled or unavailable", nil);
+        }
+        [self clearReferences];
+        return;
+    }
+
+    switch (status) {
+        case kCLAuthorizationStatusAuthorizedAlways:
+        case kCLAuthorizationStatusAuthorizedWhenInUse: {
+            [self startUpdatingLocation];
+            break;
+        }
+        case kCLAuthorizationStatusNotDetermined: {
+            // user has not authorized or denied yet
+            break;
+        }
+        case kCLAuthorizationStatusDenied:
+        case kCLAuthorizationStatusRestricted:
+        default: {
+            if (mReject != nil) {
+                mReject(@"UNAUTHORIZED", @"Location permission denied by the user", nil);
+            }
+            [self clearReferences];
+            break;
+        }
+    }
+}
+
 - (BOOL) isAuthorized {
-    int authorizationStatus = [mLocationManager authorizationStatus];
-    
+    if (mLocationManager == nil) {
+        return NO;
+    }
+    CLAuthorizationStatus authorizationStatus = [mLocationManager authorizationStatus];
+
     return authorizationStatus == kCLAuthorizationStatusAuthorizedWhenInUse
     || authorizationStatus == kCLAuthorizationStatusAuthorizedAlways;
 }


### PR DESCRIPTION
We've been getting a steady stream of EXC_BAD_ACCESS crashes in LocationModuleImpl showing up on _dispatch_worker_thread2. Turns out CLLocationManager is thread-affine — you have to talk to it on the thread you created it on. getCurrentPosition: creates the manager on main, but locationManagerDidChangeAuthorization: was hopping onto a background queue and poking the manager from there. iOS 14+ really doesn't like that.

The original reason for the background hop was fine: +locationServicesEnabled isn't supposed to run on main because it can block. The fix just took too much stuff off-main along for the ride.

Fix
- locationManagerDidChangeAuthorization: now grabs authorizationStatus on the delegate thread, hops to background only for +locationServicesEnabled, then comes back to main before touching the manager. Moved the actual handling into a new handleAuthorizationStatus:servicesEnabled: helper.
- clearReferences bounces back to main if it's called off-main, and nils out the delegate before stopUpdatingLocation so a late callback can't land on a dead promise.
- Added the mReject != nil check in the two spots it was missing.
- Turned the file-scope statics (mTimer / mLocationManager / mResolve / mReject / mTimeout) into ivars. No behavior change, just less scary.
- isAuthorized returns NO if the manager is nil instead of messaging nil.